### PR TITLE
SKY-460 simple build workflow

### DIFF
--- a/.github/workflows/build_grazer.yaml
+++ b/.github/workflows/build_grazer.yaml
@@ -1,0 +1,42 @@
+name: Build Grazer Algos Image
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: tags for the image artifact
+      image_slug:
+        type: string
+        required: false
+        default: dgaff/grazer
+jobs:
+  ondemand-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup_qemu
+        uses: docker/setup-qemu-action@v2
+
+      - name: setup_buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: login_to_dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - uses: docker/build-push-action@v4
+        with:
+          file: Dockerfile
+          context: .
+          push: true
+          tags: |
+            ${{github.event.inputs.image_slug}}:${{ github.event.inputs.tag }}
+            ${{github.event.inputs.image_slug}}:latest
+          builder: ${{ steps.setup_buildx.name }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This adds a build pipeline not tethered to commit flow events, ie you can trigger it manually against the branch of your choosing and provide a custom tag. You can change the image slug but this doesn't really serve much purpose right now as the auth mechanism is for one set of credentials (dockerhub) so whatever you change it to will have to be writable with those credentials. 