### PR TITLE
Remove custom boundaries for treat_as_regex in word lists

### DIFF
--- a/app/algos/operators/regex.py
+++ b/app/algos/operators/regex.py
@@ -60,11 +60,7 @@ class RegexParser(BaseParser):
         """
         # Adjust boundary pattern to avoid matches around invalid delimiters like '.'
         if treat_as_regex:
-            combined_pattern = "|".join(
-                rf"{term}(?![\w-])" if is_likely_domain_or_url(term)
-                else rf"(?<![\w\-/])(?<!\.){term}(?![\w-])"
-                for term in terms_list
-            )
+            combined_pattern = "|".join(terms_list)
         else:
             combined_pattern = "|".join(
                 rf"{re2.escape(term)}(?![\w-])" if is_likely_domain_or_url(term)


### PR DESCRIPTION
A very simple change that removes the set boundaries when the word list node is in regex mode

This results in consistent behaviour with the original regex node, so we can have predictable results
Some common scenarios this might solve are when the regex is being used for:
- a language that does not typically use non-word characters between words (like japanese)
- a partial word match such as `\badvert`, or a partial term like `\bart_` and we are expecting a a `\w` character next

I haven't yet managed to figure out how to get a dev environment going for testing
So while I gave everything I could a decent study, apologies if solving this is more complicated than this very basic PR