### PR TITLE
Spike/kube workers 02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 .pdm-python
 nohup.out
 notes.md
+.secrets

--- a/app/ray/cache.py
+++ b/app/ray/cache.py
@@ -7,7 +7,7 @@ from app.ray.timing_base import TimingBase, measure_time
 from app.telemetry import Telemetry
 from app.sentry import sentry_sdk
 
-@ray.remote(max_concurrency=1000)
+@ray.remote(max_concurrency=1000) # type: ignore
 class Cache(TimingBase):
     def __init__(self, key_prefix="ray_workers", batch_size=100):
         """

--- a/app/ray/cpu_worker.py
+++ b/app/ray/cpu_worker.py
@@ -1,3 +1,4 @@
+import time
 import traceback
 import asyncio
 from asyncio import Semaphore
@@ -119,3 +120,11 @@ class CPUWorker(TimingBase):
             processes.append(self.process_manifest(algorithm_id, manifest, records, report_output))
         results = await asyncio.gather(*processes)
         return results
+
+    async def run(self):
+        # Keep the script running to maintain the actor
+        try:
+            while True:
+                time.sleep(10)
+        except KeyboardInterrupt:
+            logger.info(f"CPU Worker worker stopped.")

--- a/app/ray/gpu_worker.py
+++ b/app/ray/gpu_worker.py
@@ -1,5 +1,6 @@
 import random
 import ray
+import time
 from cachetools import LRUCache
 from typing import Any
 from app.ray.timing_base import TimingBase, measure_time
@@ -8,6 +9,8 @@ from app.models.image_nsfw_classifier import ImageNSFWClassifier
 from app.models.image_arbitrary_classifier import ImageArbitraryClassifier
 from app.models.text_embedder import TextEmbedder
 from app.models.text_arbitrary_classifier import TextArbitraryClassifier
+
+from app.logger import logger
 
 
 @ray.remote(num_gpus=1)
@@ -105,3 +108,10 @@ class GPUWorker(TimingBase):
         )
         await self.cache.bulk_cache_prediction.remote(cache_keys, predictions)
         return predictions
+    async def run(self):
+        # Keep the script running to maintain the actor
+        try:
+            while True:
+                time.sleep(10)
+        except KeyboardInterrupt:
+            logger.info(f"CPU Worker worker stopped.")

--- a/app/ray/network_worker.py
+++ b/app/ray/network_worker.py
@@ -1,3 +1,4 @@
+import time
 import numpy as np
 import ray
 from PIL import Image
@@ -10,6 +11,7 @@ from app.algorithm_asset_cacher import AlgorithmAssetCacher
 from app.helpers import dict_to_sorted_string, is_truthy
 from app.settings import HOSTNAME
 from app.ray.timing_base import TimingBase, measure_time
+from app.logger import logger
 from app.sentry import sentry_sdk
 
 @ray.remote(max_concurrency=100)
@@ -159,3 +161,11 @@ class NetworkWorker(TimingBase):
             return did
         else:
             return existing
+
+    async def run(self):
+        # Keep the script running to maintain the actor
+        try:
+            while True:
+                time.sleep(10)
+        except KeyboardInterrupt:
+            logger.info(f"NetworkWorker worker stopped.")

--- a/app/settings.py
+++ b/app/settings.py
@@ -9,9 +9,8 @@ JETSTREAM_URL = os.getenv(
 )
 REDIS_DELETE_POST_QUEUE = "grazer_delete_posts"
 CURRENT_ALGORITHMS_KEY = "current_algorithms"
-SENTRY_DSN = os.getenv(
-    "SENTRY_DSN"
-)
+SENTRY_DSN = os.getenv("SENTRY_DSN")
+
 
 class StreamerSettings(BaseSettings):
     # TODO: making this optional is a stupid LSP thing
@@ -19,3 +18,13 @@ class StreamerSettings(BaseSettings):
     aws_region: str = "us-east-1"
     sqs_polling_interval: int = 10
     noop: bool = True
+
+
+class OmniBootSettings(BaseSettings):
+    """Some switches to control the behavior of the booting script"""
+
+    boot_gpu: bool = False
+    boot_cpu: bool = True
+    boot_cache: bool = True
+    boot_network: bool = True
+    boot_consumer: bool = False

--- a/omni_boot.py
+++ b/omni_boot.py
@@ -15,7 +15,6 @@ boot_settings = OmniBootSettings()
 
 DEFAULT_NAMESPACE = "main"
 
-
 async def boot_cache(num_cpus: float, num_gpus: float):
     from app.ray.semaphore import SemaphoreActor
     from app.ray.cache import Cache
@@ -36,9 +35,6 @@ async def boot_cache(num_cpus: float, num_gpus: float):
         num_gpus=num_gpus,
         namespace=DEFAULT_NAMESPACE,
     ).remote()
-
-    # can't validate remote object ref on actors
-    # ray.get([bsky_actor, graze_actor, cache_actor], timeout=300)
 
 
 async def boot_network(num_workers: int, num_cpus: float, num_gpus: int):

--- a/omni_boot.py
+++ b/omni_boot.py
@@ -1,15 +1,8 @@
 import asyncio
 import ray
 import uuid
-from app.sqs_consumer import SQSConsumer
 
-
-
-from app.ray.cache import Cache
-from app.ray.semaphore import SemaphoreActor
-from app.ray.network_worker import NetworkWorker
-from app.ray.cpu_worker import CPUWorker
-from app.ray.gpu_worker import GPUWorker
+from app.settings import OmniBootSettings
 
 from app.ray.utils import (
     discover_named_actors,
@@ -18,27 +11,39 @@ from app.ray.utils import (
 
 from app.logger import logger
 
-namespace = "main"
+boot_settings = OmniBootSettings()
+
+DEFAULT_NAMESPACE = "main"
+
 
 async def boot_cache(num_cpus: float, num_gpus: float):
+    from app.ray.semaphore import SemaphoreActor
+    from app.ray.cache import Cache
+
     SemaphoreActor.options(
-        name="semaphore:bluesky", lifetime="detached", namespace=namespace
+        name="semaphore:bluesky", lifetime="detached", namespace=DEFAULT_NAMESPACE
     ).remote()
 
     SemaphoreActor.options(
-        name="semaphore:graze", lifetime="detached", namespace=namespace
-    ).remote(10)# type: ignore
+        name="semaphore:graze", lifetime="detached", namespace=DEFAULT_NAMESPACE
+    ).remote(10)  # type: ignore
 
     # Start the Cache actor with the specified resources and name
-    Cache.options( # type: ignore
-        name="cache:main", lifetime="detached", num_cpus=num_cpus, num_gpus=num_gpus, namespace=namespace
+    Cache.options(  # type: ignore
+        name="cache:main",
+        lifetime="detached",
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        namespace=DEFAULT_NAMESPACE,
     ).remote()
 
     # can't validate remote object ref on actors
     # ray.get([bsky_actor, graze_actor, cache_actor], timeout=300)
 
 
-async def boot_network(num_workers: int, num_cpus:float, num_gpus:int):
+async def boot_network(num_workers: int, num_cpus: float, num_gpus: int):
+    from app.ray.network_worker import NetworkWorker
+
     bluesky_semaphore = discover_named_actor("semaphore:bluesky", timeout=10)
     graze_semaphore = discover_named_actor("semaphore:graze", timeout=10)
     cache = discover_named_actor("cache:", timeout=10)
@@ -47,7 +52,7 @@ async def boot_network(num_workers: int, num_cpus:float, num_gpus:int):
     for i in range(num_workers):
         uuid_str = str(uuid.uuid4())
         network_workers.append(
-            NetworkWorker.options( #type: ignore
+            NetworkWorker.options(  # type: ignore
                 name=f"{name}-{i}-{uuid_str}",
                 lifetime="detached",
                 num_cpus=num_cpus,
@@ -60,10 +65,12 @@ async def boot_network(num_workers: int, num_cpus:float, num_gpus:int):
     )
 
     # run the loop for each worker
-    ray.get([network_worker.run.remote() for network_worker in network_workers]) #type: ignore
+    ray.get([network_worker.run.remote() for network_worker in network_workers])  # type: ignore
 
 
-async def boot_cpu(num_cpus:float, num_gpus:float, num_workers:int):
+async def boot_cpu(num_cpus: float, num_gpus: float, num_workers: int):
+    from app.ray.cpu_worker import CPUWorker
+
     name = "cpu:main"
     network_workers = discover_named_actors("network:", timeout=10)
     gpu_embedding_workers = discover_named_actors("gpu:embedders", timeout=10)
@@ -74,20 +81,23 @@ async def boot_cpu(num_cpus:float, num_gpus:float, num_workers:int):
     for i in range(num_workers):
         uuid_str = str(uuid.uuid4())
         cpu_workers.append(
-            CPUWorker.options( #type: ignore
+            CPUWorker.options(  # type: ignore
                 name=f"{name}-{i}-{uuid_str}",
                 lifetime="detached",
                 num_cpus=num_cpus,
                 num_gpus=num_gpus,
-                namespace=namespace
+                namespace=DEFAULT_NAMESPACE,
             ).remote(
                 gpu_embedding_workers, gpu_classifier_workers, network_workers, cache
             )
         )
 
-    ray.get([cpu_worker.run.remote() for cpu_worker in cpu_workers]) #type: ignore
+    ray.get([cpu_worker.run.remote() for cpu_worker in cpu_workers])  # type: ignore
 
-async def boot_gpu(num_cpus:float, num_gpus:float, num_workers:int):
+
+async def boot_gpu(num_cpus: float, num_gpus: float, num_workers: int):
+    from app.ray.gpu_worker import GPUWorker
+
     name = "gpu:main"
     # Discover network workers and cache workers
     network_workers = discover_named_actors("network:", timeout=10)
@@ -95,33 +105,50 @@ async def boot_gpu(num_cpus:float, num_gpus:float, num_workers:int):
     gpu_workers = []
     for i in range(num_workers):
         uuid_str = str(uuid.uuid4())
-        gpu_workers.append(GPUWorker.options(
-            name=f"{name}:embedders-{i}-{uuid_str}",
+        gpu_workers.append(
+            GPUWorker.options(
+                name=f"{name}:embedders-{i}-{uuid_str}",
+                lifetime="detached",
+                num_cpus=num_cpus,
+                num_gpus=num_gpus,
+            ).remote(network_workers, cache)
+        )
+
+    gpu_workers.append(
+        GPUWorker.options(
+            name=f"{name}:classifiers",
             lifetime="detached",
             num_cpus=num_cpus,
             num_gpus=num_gpus,
-        ).remote(network_workers, cache))
+        ).remote(network_workers, cache)
+    )
 
-    gpu_workers.append(GPUWorker.options(
-        name=f"{name}:classifiers",
-        lifetime="detached",
-        num_cpus=num_cpus,
-        num_gpus=num_gpus,
-    ).remote(network_workers, cache))
+    ray.get([gpu_worker.run.remote() for gpu_worker in gpu_workers])  # type: ignore
 
-    ray.get([gpu_worker.run.remote() for gpu_worker in gpu_workers]) #type: ignore
 
 async def boot_consumer():
-    consumer = SQSConsumer.options(max_concurrency=10, lifetime="detached").remote()
+    from app.sqs_consumer import SQSConsumer
+
+    consumer = SQSConsumer.options(
+        max_concurrency=10,
+        lifetime="detached",
+        namespace=DEFAULT_NAMESPACE,
+        num_cpus=0.5,
+    ).remote()
     ray.get([consumer.run.remote()])  # type: ignore
 
 
 async def omni_boot():
-    await boot_cache(num_cpus=0.5, num_gpus=0)
-    await boot_network(num_workers=1, num_cpus=0.1, num_gpus=0)
-    await boot_cpu(num_cpus=0.5, num_gpus=0, num_workers=1)
-    await boot_gpu(num_cpus=0, num_gpus=0.5, num_workers=1)
-    await boot_consumer()
+    if boot_settings.boot_cache:
+        await boot_cache(num_cpus=0.5, num_gpus=0)
+    if boot_settings.boot_network:
+        await boot_network(num_workers=3, num_cpus=0.1, num_gpus=0)
+    if boot_settings.boot_cpu:
+        await boot_cpu(num_cpus=0.5, num_gpus=0, num_workers=3)
+    if boot_settings.boot_gpu:
+        await boot_gpu(num_cpus=0, num_gpus=0.5, num_workers=1)
+    if boot_settings.boot_consumer:
+        await boot_consumer()
 
 
 if __name__ == "__main__":

--- a/omni_boot.py
+++ b/omni_boot.py
@@ -1,0 +1,128 @@
+import asyncio
+import ray
+import uuid
+from app.sqs_consumer import SQSConsumer
+
+
+
+from app.ray.cache import Cache
+from app.ray.semaphore import SemaphoreActor
+from app.ray.network_worker import NetworkWorker
+from app.ray.cpu_worker import CPUWorker
+from app.ray.gpu_worker import GPUWorker
+
+from app.ray.utils import (
+    discover_named_actors,
+    discover_named_actor,
+)
+
+from app.logger import logger
+
+namespace = "main"
+
+async def boot_cache(num_cpus: float, num_gpus: float):
+    SemaphoreActor.options(
+        name="semaphore:bluesky", lifetime="detached", namespace=namespace
+    ).remote()
+
+    SemaphoreActor.options(
+        name="semaphore:graze", lifetime="detached", namespace=namespace
+    ).remote(10)# type: ignore
+
+    # Start the Cache actor with the specified resources and name
+    Cache.options( # type: ignore
+        name="cache:main", lifetime="detached", num_cpus=num_cpus, num_gpus=num_gpus, namespace=namespace
+    ).remote()
+
+    # can't validate remote object ref on actors
+    # ray.get([bsky_actor, graze_actor, cache_actor], timeout=300)
+
+
+async def boot_network(num_workers: int, num_cpus:float, num_gpus:int):
+    bluesky_semaphore = discover_named_actor("semaphore:bluesky", timeout=10)
+    graze_semaphore = discover_named_actor("semaphore:graze", timeout=10)
+    cache = discover_named_actor("cache:", timeout=10)
+    network_workers = []
+    name = "network:main"
+    for i in range(num_workers):
+        uuid_str = str(uuid.uuid4())
+        network_workers.append(
+            NetworkWorker.options( #type: ignore
+                name=f"{name}-{i}-{uuid_str}",
+                lifetime="detached",
+                num_cpus=num_cpus,
+                num_gpus=num_gpus,
+            ).remote(cache, bluesky_semaphore, graze_semaphore)
+        )
+
+    logger.info(
+        f"NetworkWorker worker '{name}' started with {num_cpus} CPUs and {num_gpus} GPUs and running..."
+    )
+
+    # run the loop for each worker
+    ray.get([network_worker.run.remote() for network_worker in network_workers]) #type: ignore
+
+
+async def boot_cpu(num_cpus:float, num_gpus:float, num_workers:int):
+    name = "cpu:main"
+    network_workers = discover_named_actors("network:", timeout=10)
+    gpu_embedding_workers = discover_named_actors("gpu:embedders", timeout=10)
+    gpu_classifier_workers = discover_named_actors("gpu:classifiers", timeout=10)
+    cache = discover_named_actor("cache:", timeout=10)
+    logger.info(f"Creating a new CPUWorker: {name}")
+    cpu_workers = []
+    for i in range(num_workers):
+        uuid_str = str(uuid.uuid4())
+        cpu_workers.append(
+            CPUWorker.options( #type: ignore
+                name=f"{name}-{i}-{uuid_str}",
+                lifetime="detached",
+                num_cpus=num_cpus,
+                num_gpus=num_gpus,
+                namespace=namespace
+            ).remote(
+                gpu_embedding_workers, gpu_classifier_workers, network_workers, cache
+            )
+        )
+
+    ray.get([cpu_worker.run.remote() for cpu_worker in cpu_workers]) #type: ignore
+
+async def boot_gpu(num_cpus:float, num_gpus:float, num_workers:int):
+    name = "gpu:main"
+    # Discover network workers and cache workers
+    network_workers = discover_named_actors("network:", timeout=10)
+    cache = discover_named_actor("cache:", timeout=10)
+    gpu_workers = []
+    for i in range(num_workers):
+        uuid_str = str(uuid.uuid4())
+        gpu_workers.append(GPUWorker.options(
+            name=f"{name}:embedders-{i}-{uuid_str}",
+            lifetime="detached",
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+        ).remote(network_workers, cache))
+
+    gpu_workers.append(GPUWorker.options(
+        name=f"{name}:classifiers",
+        lifetime="detached",
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+    ).remote(network_workers, cache))
+
+    ray.get([gpu_worker.run.remote() for gpu_worker in gpu_workers]) #type: ignore
+
+async def boot_consumer():
+    consumer = SQSConsumer.options(max_concurrency=10, lifetime="detached").remote()
+    ray.get([consumer.run.remote()])  # type: ignore
+
+
+async def omni_boot():
+    await boot_cache(num_cpus=0.5, num_gpus=0)
+    await boot_network(num_workers=1, num_cpus=0.1, num_gpus=0)
+    await boot_cpu(num_cpus=0.5, num_gpus=0, num_workers=1)
+    await boot_gpu(num_cpus=0, num_gpus=0.5, num_workers=1)
+    await boot_consumer()
+
+
+if __name__ == "__main__":
+    asyncio.run(omni_boot())

--- a/omni_env.yaml
+++ b/omni_env.yaml
@@ -1,0 +1,9 @@
+# example env
+working_dir: .
+pip:
+  - "aioboto3>=14.1.0"
+  - "websockets==13.1"
+  - "types-aioboto3[sqs]"
+  - "pydantic-settings"
+  - "pandas>=2.1.2"
+env_vars: {}


### PR DESCRIPTION
@DGaffney I have gotten this to work somewhat, with various problems ironing out the dependency issues and resource allocation on startup. Essentially moving a generic `run` function to the worker classes allows them to exist indefinitely, after the job has been submitted. if we want to kill them we have to do so manually before redeploying. I still have to figure out how this works with autoscaling, so I need to tweak a few values on the algo cluster. 