### PR TITLE
fix: testing get or creating actors

### DIFF
--- a/app/kube/processor.py
+++ b/app/kube/processor.py
@@ -1,13 +1,16 @@
 import random
 import asyncio
 
+from app.ray.dispatcher import Dispatcher
 from app.logic_evaluator import LogicEvaluator
 from app.logger import logger
 from app.kube.base import KubeBase
 from app.helpers import chunk
 from app.redis import RedisClient
-from app.settings import CURRENT_ALGORITHMS_KEY
+from app.settings import CURRENT_ALGORITHMS_KEY, EgressSettings
 
+
+has_egress = EgressSettings().egress_enabled
 
 class KubeProcessor(KubeBase):
     @classmethod
@@ -36,7 +39,7 @@ class KubeProcessor(KubeBase):
         )
 
     @classmethod
-    async def run_algos(cls, dispatcher, records, manifests, all_operators):
+    async def run_algos(cls, dispatcher: Dispatcher, records, manifests, all_operators):
         manifests = list(manifests.items())
         random.shuffle(manifests)
         # await run_precache(dispatcher, records, [{}], all_operators)
@@ -52,7 +55,7 @@ class KubeProcessor(KubeBase):
                     )
                     algorithm_ids.append(algorithm_id)
             manifest_data = list(zip(algorithm_ids, hydrated_manifests))
-            await dispatcher.distribute_tasks(records, manifest_data, False)
+            await dispatcher.distribute_tasks(records, manifest_data, has_egress)
             while len(asyncio.all_tasks()) > 100:
                 logger.info(f"Current Task Depth is {len(asyncio.all_tasks())}")
                 asyncio.sleep(1)

--- a/app/ray/cpu_worker.py
+++ b/app/ray/cpu_worker.py
@@ -12,7 +12,7 @@ from app.ray.timing_base import TimingBase, measure_time
 from app.sentry import sentry_sdk
 from app.telemetry import Telemetry
 
-@ray.remote(max_concurrency=5)
+@ray.remote(max_concurrency=5) #type: ignore
 class CPUWorker(TimingBase):
     def __init__(
         self,
@@ -123,8 +123,11 @@ class CPUWorker(TimingBase):
 
     async def run(self):
         # Keep the script running to maintain the actor
+        logger.info(
+            "CPUWorker worker booting.."
+        )
         try:
             while True:
                 time.sleep(10)
         except KeyboardInterrupt:
-            logger.info(f"CPU Worker worker stopped.")
+            logger.info("CPU Worker worker stopped.")

--- a/app/ray/network_worker.py
+++ b/app/ray/network_worker.py
@@ -14,7 +14,7 @@ from app.ray.timing_base import TimingBase, measure_time
 from app.logger import logger
 from app.sentry import sentry_sdk
 
-@ray.remote(max_concurrency=100)
+@ray.remote(max_concurrency=100) #type: ignore
 class NetworkWorker(TimingBase):
     def __init__(self, cache, bluesky_semaphore, graze_semaphore):
         """
@@ -163,9 +163,11 @@ class NetworkWorker(TimingBase):
             return existing
 
     async def run(self):
-        # Keep the script running to maintain the actor
+        logger.info(
+            "NetworkWorker worker booting..."
+        )
         try:
             while True:
                 time.sleep(10)
         except KeyboardInterrupt:
-            logger.info(f"NetworkWorker worker stopped.")
+            logger.info("NetworkWorker worker stopped.")

--- a/app/settings.py
+++ b/app/settings.py
@@ -11,6 +11,8 @@ REDIS_DELETE_POST_QUEUE = "grazer_delete_posts"
 CURRENT_ALGORITHMS_KEY = "current_algorithms"
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 
+class EgressSettings(BaseSettings):
+    egress_enabled: bool = False
 
 class StreamerSettings(BaseSettings):
     # TODO: making this optional is a stupid LSP thing
@@ -18,7 +20,6 @@ class StreamerSettings(BaseSettings):
     aws_region: str = "us-east-1"
     sqs_polling_interval: int = 10
     noop: bool = True
-
 
 class OmniBootSettings(BaseSettings):
     """Some switches to control the behavior of the booting script"""

--- a/omni_boot.py
+++ b/omni_boot.py
@@ -5,6 +5,7 @@ import uuid
 from app.settings import OmniBootSettings
 
 from app.ray.utils import (
+    get_or_create_actor,
     discover_named_actors,
     discover_named_actor,
 )
@@ -15,26 +16,49 @@ boot_settings = OmniBootSettings()
 
 DEFAULT_NAMESPACE = "main"
 
+
 async def boot_cache(num_cpus: float, num_gpus: float):
     from app.ray.semaphore import SemaphoreActor
     from app.ray.cache import Cache
 
-    SemaphoreActor.options(
-        name="semaphore:bluesky", lifetime="detached", namespace=DEFAULT_NAMESPACE
-    ).remote()
+    get_or_create_actor(
+        SemaphoreActor,
+        namespace=DEFAULT_NAMESPACE,
+        name="semaphore:bluesky",
+        lifetime="detached",
+        kill=True,
+    )
 
-    SemaphoreActor.options(
-        name="semaphore:graze", lifetime="detached", namespace=DEFAULT_NAMESPACE
-    ).remote(10)  # type: ignore
+    logger.info(
+         f"Semaphore Actor 'sempaphore:blueseky' started with {num_cpus} CPUs and {num_gpus} GPUs and running..."
+     )
 
-    # Start the Cache actor with the specified resources and name
-    Cache.options(  # type: ignore
+    get_or_create_actor(
+        SemaphoreActor,
+        10,
+        name="semaphore:graze",
+        lifetime="detached",
+        namespace=DEFAULT_NAMESPACE,
+    )
+
+    logger.info(
+         f"Semaphore Actor 'sempaphore:graze' started with {num_cpus} CPUs and {num_gpus} GPUs and running..."
+     )
+
+
+    get_or_create_actor(
+        Cache,
         name="cache:main",
         lifetime="detached",
         num_cpus=num_cpus,
         num_gpus=num_gpus,
         namespace=DEFAULT_NAMESPACE,
-    ).remote()
+    )
+
+    logger.info(
+         f"Cache worker 'cahe:main' started with {num_cpus} CPUs and {num_gpus} GPUs and running..."
+     )
+
 
 
 async def boot_network(num_workers: int, num_cpus: float, num_gpus: int):
@@ -56,12 +80,11 @@ async def boot_network(num_workers: int, num_cpus: float, num_gpus: int):
             ).remote(cache, bluesky_semaphore, graze_semaphore)
         )
 
+    [network_worker.run.remote() for network_worker in network_workers]
+
     logger.info(
         f"NetworkWorker worker '{name}' started with {num_cpus} CPUs and {num_gpus} GPUs and running..."
     )
-
-    # run the loop for each worker
-    ray.get([network_worker.run.remote() for network_worker in network_workers])  # type: ignore
 
 
 async def boot_cpu(num_cpus: float, num_gpus: float, num_workers: int):
@@ -87,8 +110,8 @@ async def boot_cpu(num_cpus: float, num_gpus: float, num_workers: int):
                 gpu_embedding_workers, gpu_classifier_workers, network_workers, cache
             )
         )
+    [cpu_worker.run.remote() for cpu_worker in cpu_workers]
 
-    ray.get([cpu_worker.run.remote() for cpu_worker in cpu_workers])  # type: ignore
 
 
 async def boot_gpu(num_cpus: float, num_gpus: float, num_workers: int):
@@ -119,7 +142,8 @@ async def boot_gpu(num_cpus: float, num_gpus: float, num_workers: int):
         ).remote(network_workers, cache)
     )
 
-    ray.get([gpu_worker.run.remote() for gpu_worker in gpu_workers])  # type: ignore
+    [gpu_worker.run.remote() for gpu_worker in gpu_workers]
+
 
 
 async def boot_consumer():
@@ -131,7 +155,9 @@ async def boot_consumer():
         namespace=DEFAULT_NAMESPACE,
         num_cpus=0.5,
     ).remote()
-    ray.get([consumer.run.remote()])  # type: ignore
+
+    consumer_object = consumer.run.remote()  # type: ignore
+    # ray.get([consumer.run.remote()])  # type: ignore
 
 
 async def omni_boot():
@@ -143,7 +169,7 @@ async def omni_boot():
         await boot_network(num_workers=3, num_cpus=0.1, num_gpus=0)
     if boot_settings.boot_cpu:
         logger.info("Booting CPU Worker")
-        await boot_cpu(num_cpus=0.5, num_gpus=0, num_workers=3)
+        await boot_cpu(num_cpus=0.5, num_gpus=0, num_workers=2)
     if boot_settings.boot_gpu:
         logger.info("Booting GPU Worker")
         await boot_gpu(num_cpus=0, num_gpus=0.5, num_workers=1)

--- a/omni_env.yaml
+++ b/omni_env.yaml
@@ -6,4 +6,7 @@ pip:
   - "types-aioboto3[sqs]"
   - "pydantic-settings"
   - "pandas>=2.1.2"
-env_vars: {}
+env_vars:
+  BOOT_CPU: "true"
+  BOOT_CONSUMER: "true"
+  RAY_DEDUP_LOGS: "0"


### PR DESCRIPTION
@DGaffney Here I have some tweaks to the omni boot to get/create named actors. Getting actors by name on a fresh Ray cluster throws an error, so there's an try catch in there to just create in that case. I have this working for the cache, actors, but the CPU workers I am leaving to multiple creation.

Note: Unrelated you might noted I added some type hints for my LSP in random places. 